### PR TITLE
Closes #13 | fix: Prevent merging dev & prod css loaders

### DIFF
--- a/build/webpack/base.config.ts
+++ b/build/webpack/base.config.ts
@@ -19,20 +19,6 @@ const config: webpack.Configuration = {
         exclude: /node_modules/,
       },
       {
-        test: /\.s?css$/i,
-        use: [
-          'style-loader',
-          'css-loader',
-          {
-            loader: 'sass-loader',
-            options: {
-              // Prefer `dart-sass`
-              implementation: require('sass'),
-            },
-          },
-        ],
-      },
-      {
         test: /\.(png|svg|jpe?g|gif)$/i,
         type: 'asset/resource',
       },

--- a/build/webpack/dev.config.ts
+++ b/build/webpack/dev.config.ts
@@ -14,6 +14,24 @@ const devConfig: webpack.Configuration = {
     compress: true,
     port: 3000,
   },
+  module: {
+    rules: [
+      {
+        test: /\.s?css$/i,
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              // Prefer `dart-sass`
+              implementation: require('sass'),
+            },
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export default merge(baseConfig, devConfig);


### PR DESCRIPTION
The production configuration for Sass/CSS was being added with development mode sass/css configuration.  This resulted the dev mode test being hit first and applied, using `style-loader` (which loads CSS in JS).  The solution was to move the development mode sass loader to the devConfig so the test would not be duplicated.